### PR TITLE
fix: handle missing customizations key to prevent MediaPlayerThread crash

### DIFF
--- a/actions/cores/customization_core/customization_settings.py
+++ b/actions/cores/customization_core/customization_settings.py
@@ -19,7 +19,7 @@ class CustomizationSettings(BaseSettings):
 
     def get_customizations(self):
         return [self.customization_implementation.from_dict(c) for c in
-                self._action.get_settings()[self.customization_name][customization_const.SETTING_CUSTOMIZATIONS]]
+                self._action.get_settings()[self.customization_name].get(customization_const.SETTING_CUSTOMIZATIONS, [])]
 
     def move_customization(self, index: int, offset: int):
         """


### PR DESCRIPTION
## What

`get_customizations()` in `CustomizationSettings` used a bare dict subscript to read the `customizations` key:

```python
self._action.get_settings()[self.customization_name][customization_const.SETTING_CUSTOMIZATIONS]
```

When the `customizations` key is absent — which is the default state for any newly configured `ShowText` or other customization-based action — this raises a `KeyError`.

## Why it matters

The exception isn't caught at the call site. It propagates up through `on_ready()` into `MediaPlayerThread`, killing the thread. Since `MediaPlayerThread` is responsible for rendering all button images on the deck, **every dynamic button stops rendering** — clock, CPU, weather, sensor values, all of it. Button presses still work (separate input thread) so the failure mode is subtle: the deck looks static but responds to presses, with no obvious error surfaced to the user.

This is reproducible with a fresh `ShowText` action that has never had a customization added to it.

## Fix

Replace the bare subscript with `.get(..., [])` so a missing key returns an empty list instead of crashing:

```python
self._action.get_settings()[self.customization_name].get(customization_const.SETTING_CUSTOMIZATIONS, [])
```

One-line change. Consistent with how the key would logically be treated if absent (no customizations configured = empty list).

## Related

Similar MediaPlayerThread crash pattern to #5 and #19, but a distinct root cause in a different code path.