### PR TITLE
Fix AttributeError when changing domain in action config

### DIFF
--- a/actions/cores/base_core/base_core.py
+++ b/actions/cores/base_core/base_core.py
@@ -118,7 +118,7 @@ class BaseCore(ActionCore):
                 self.plugin_base.backend.remove_tracked_entity(entity, self.refresh)
             self.settings.reset(domain)
             # save entities from the combo to a temporary variable to keep them alive while we clear the combo
-            _temp_keep_alive = [self.entity_combo.get_item(i) for i in range(self.entity_combo.get_n_items())]
+            _temp_keep_alive = [self.entity_combo.get_item_at(i) for i in range(self.entity_combo.get_item_amount())]
             self.entity_combo.remove_all_items()
             # now the entities can be removed
             del _temp_keep_alive

--- a/test/actions/cores/base_core/test_base_core_on_change_domain.py
+++ b/test/actions/cores/base_core/test_base_core_on_change_domain.py
@@ -58,7 +58,7 @@ class TestBaseCoreOnChangeDomain(unittest.TestCase):
 
         entity_combo_mock = Mock()
         entity_combo_mock.remove_all_items = remove_all_items_mock
-        entity_combo_mock.get_n_items = Mock(return_value=0)
+        entity_combo_mock.get_item_amount = Mock(return_value=0)
 
         domain = "light"
 
@@ -90,7 +90,7 @@ class TestBaseCoreOnChangeDomain(unittest.TestCase):
 
         entity_combo_mock = Mock()
         entity_combo_mock.remove_all_items = remove_all_items_mock
-        entity_combo_mock.get_n_items = Mock(return_value=0)
+        entity_combo_mock.get_item_amount = Mock(return_value=0)
 
         domain = "light"
 
@@ -122,7 +122,7 @@ class TestBaseCoreOnChangeDomain(unittest.TestCase):
 
         entity_combo_mock = Mock()
         entity_combo_mock.remove_all_items = remove_all_items_mock
-        entity_combo_mock.get_n_items = Mock(return_value=0)
+        entity_combo_mock.get_item_amount = Mock(return_value=0)
 
         domain = None
 
@@ -154,7 +154,7 @@ class TestBaseCoreOnChangeDomain(unittest.TestCase):
 
         entity_combo_mock = Mock()
         entity_combo_mock.remove_all_items = remove_all_items_mock
-        entity_combo_mock.get_n_items = Mock(return_value=0)
+        entity_combo_mock.get_item_amount = Mock(return_value=0)
 
         domain = "light"
 
@@ -184,7 +184,7 @@ class TestBaseCoreOnChangeDomain(unittest.TestCase):
         settings_mock.reset = Mock()
 
         entity_combo_mock = Mock()
-        entity_combo_mock.get_n_items = Mock(return_value=0)
+        entity_combo_mock.get_item_amount = Mock(return_value=0)
 
         instance = BaseCore(Mock(), True)
         instance.initialized = True

--- a/test/stream_controller_mock/GtkHelper/GenerativeUI/ComboRow.py
+++ b/test/stream_controller_mock/GtkHelper/GenerativeUI/ComboRow.py
@@ -20,6 +20,9 @@ class ComboRow:
     def get_item_amount(self) -> int:
         return len(self.args[3])
 
+    def get_item_at(self, index: int):
+        return self.args[3][index]
+
     @property
     def widget(self):
         return self._widget


### PR DESCRIPTION
Fixes #29 

on_change_domain called get_n_items()/get_item(index) on the GenerativeUI ComboRow wrapper, but that API belongs to Gio.ListModel. The wrapper exposes get_item_amount() and get_item_at(index) instead (its get_item() looks items up by name, not index).

The error aborted the handler mid-way, so the entity combo was never cleared and entities for the newly selected domain were never loaded.

Also update the unit tests to stub the real method name (the old stubs made the nonexistent get_n_items appear to exist) and add get_item_at to the stream_controller_mock ComboRow for API parity.